### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,6 +427,16 @@ series:
     group_by:
       func: sum
       duration: 1month
+apex_config:
+  tooltip:
+    x:
+      formatter: |
+        EVAL: (value) => {
+          const date = new Date(value);
+          date.setDate(date.getDate() + 5);
+          const formatter = new Intl.DateTimeFormat(navigator.language, { year: 'numeric', month: 'long' });
+          return formatter.format(date);          
+        }
 ```
 ![](/obrazky/pnd-vsechnadata-mesicni.png)
 

--- a/README.md
+++ b/README.md
@@ -398,7 +398,10 @@ series:
     attribute: production
     data_generator: |
       return entity.attributes.pnddate.map((pnd, index) => {
-        return [new Date(pnd).getTime(), entity.attributes.production[index]];
+        const date = new Date(pnd);
+        date.setDate(1);
+        date.setHours(0, 0, 0, 0);      
+        return [date.getTime(), entity.attributes.production[index]];
       });
     color: var(--success-color)
     opacity: 0.8
@@ -412,7 +415,10 @@ series:
     attribute: consumption
     data_generator: |
       return entity.attributes.pnddate.map((pnd, index) => {
-        return [new Date(pnd).getTime(), entity.attributes.consumption[index]];
+        const date = new Date(pnd);
+        date.setDate(1);
+        date.setHours(0, 0, 0, 0);
+        return [date.getTime(), entity.attributes.consumption[index]];
       });
     color: var(--error-color)
     opacity: 0.8


### PR DESCRIPTION
apexchart-card neumi seskupovat po kalendarnich mesicich (https://github.com/RomRider/apexcharts-card?tab=readme-ov-file#group_by-options mesic bere jako 30 dni, datum je tudiz nutno konvertovat na prvni den v mesici, aby byl zapocten do spravneho bucketu a hodnota odpovidala mesicnim souctum na PND.
~Bohuzel jsem neprisel, jak spravit zobrazeni datumu mesice, pro leden to zobrazuje 30.12.2024, asi kvuli tem 30 dennim bucketum.~ I mesic bude.
