### PR TITLE
fix: měsíční agregace v grafu

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,7 @@ stacked: true
 graph_span: 1y
 span:
   end: month
+  offset: "-1d"
 header:
   show: true
   title: PND Historická Data (Měsíční agregace)

--- a/README.md
+++ b/README.md
@@ -416,7 +416,7 @@ series:
     data_generator: |
       return entity.attributes.pnddate.map((pnd, index) => {
         const date = new Date(pnd);
-        date.setDate(1);
+        date.setDate(2);
         date.setHours(0, 0, 0, 0);
         return [date.getTime(), entity.attributes.consumption[index]];
       });

--- a/README.md
+++ b/README.md
@@ -389,7 +389,6 @@ stacked: true
 graph_span: 1y
 span:
   end: month
-  offset: "-1d"
 header:
   show: true
   title: PND Historická Data (Měsíční agregace)
@@ -400,7 +399,7 @@ series:
     data_generator: |
       return entity.attributes.pnddate.map((pnd, index) => {
         const date = new Date(pnd);
-        date.setDate(1);
+        date.setDate(2);
         date.setHours(0, 0, 0, 0);      
         return [date.getTime(), entity.attributes.production[index]];
       });


### PR DESCRIPTION
Aktuálně se nezobrazují správně měsíční agregace v posledních dvou měsících - data z března se připočítávají k únoru. ~Nastavení offsetu -1d pro span to vyřeší, nevím přesně proč, ale takto to funguje.~
Vypadá, že to je problém s časovou zónou, nastavení času na půlnoc způsobuje posun datumu do jiného dne. Nastavení datumu na 2. den v měsíci by to měl vyřešit, tak aby se všechny hodnoty v měsíci agregovaly do správného měsíce.

Opravuje https://github.com/ondrejvysek/HomeAssistant-CEZDistribuce-PND/issues/65