### PR TITLE
Implement automatic startup helper and fix missing math import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.Python
+env/
+venv/
+pip-log.txt
+pip-delete-this-directory.txt
+.tox/
+.coverage
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/

--- a/README.md
+++ b/README.md
@@ -190,6 +190,42 @@ action:
 mode: single
 ```
 
+### Automatické spuštění po restartu AppDaemon
+Pokud chcete zajistit, aby se skript spustil automaticky po každém restartu AppDaemonu (např. po restartu celého Home Assistanta), můžete využít následující pomocný skript a automatizaci. Toto řešení pomáhá zejména v situacích, kdy se po startu systému skript sám nevyvolá (nápad a řešení od uživatele @wejto).
+
+1. Ve složce `apps/pnd/` (nebo tam, kde máte `pnd.py`) vytvořte nový soubor `init_helper.py` s tímto obsahem:
+```python
+import appdaemon.plugins.hass.hassapi as hass
+
+class InitHelper(hass.Hass):
+    def initialize(self):
+        self.fire_event("APPDAEMON_READY")
+```
+
+2. V souboru `apps.yaml` přidejte nad (nebo pod) definici `pnd` tento blok:
+```yaml
+init_helper:
+  module: init_helper
+  class: InitHelper
+```
+
+3. V Home Assistantu vytvořte novou automatizaci (přepněte do YAML režimu), která zachytí událost `APPDAEMON_READY`:
+```yaml
+alias: Run actions after AppDaemon starts
+description: Spustí PND po startu AppDaemonu s prodlevou 15 sekund pro zajištění závislostí
+trigger:
+  - platform: event
+    event_type: "APPDAEMON_READY"
+condition: []
+action:
+  - delay:
+      seconds: 15
+  - event: run_pnd
+    event_data: {}
+mode: single
+```
+Tímto zajistíte, že se skript spustí 15 sekund po úplném načtení všech aplikací v AppDaemonu.
+
 ### Řešení problémů se skriptem
 Nejprve zkuste spustit znovu, skript simuluje pohyb na webové stránce a není garantováno, že stránka bude vždy stejná a skript doběhne úspěšně dokonce, případně restartujte AppDaemon a spusťe skript znovu.
 
@@ -391,6 +427,10 @@ Pokud máte nějaké přání, nápad na vylepšení - vytvořte požadavek zde 
 - [ ] Refactor některých částí pro stabilitu při timeoutech, bezpečnost a kvalitu kódu
       
 # Změny
+
+## 20.4.2026 v1.0.1
+ - [x] Přidána podpora pro automatické spuštění po restartu AppDaemon (díky @wejto).
+ - [x] Oprava chybějícího importu modulu `math`.
 
 ## 18.4.2026 v1.0.0
  - [x] Sjednocení enginů - podpora automatického přepnutí z Google Chrome na Mozilla Firefox v případě pádu či chybějícího ovladače.

--- a/README.md
+++ b/README.md
@@ -143,6 +143,10 @@ logs:
 
 ```
 ---
+init_helper:
+  module: init_helper
+  class: InitHelper
+
 pnd:
   module: pnd
   class: pnd
@@ -193,16 +197,9 @@ mode: single
 ### Automatické spuštění po restartu AppDaemon
 Pokud chcete zajistit, aby se skript spustil automaticky po každém restartu AppDaemonu (např. po restartu celého Home Assistanta), můžete využít pomocný skript `init_helper.py` a automatizaci v Home Assistantu. Toto řešení pomáhá zejména v situacích, kdy se po startu systému skript sám nevyvolá (nápad a řešení od uživatele @wejto).
 
-1. Ujistěte se, že ve složce `apps/pnd/` (nebo tam, kde máte `pnd.py`) existuje soubor `init_helper.py`.
+Pomocný skript `init_helper.py` je součástí instalace a stačí jej pouze aktivovat v `apps.yaml` (viz [Vytvoření aplikace PND v AppDaemon](#vytvoření-aplikace-pnd-v-appdaemon)).
 
-2. V souboru `apps.yaml` přidejte nad (nebo pod) definici `pnd` tento blok:
-```yaml
-init_helper:
-  module: init_helper
-  class: InitHelper
-```
-
-3. V Home Assistantu vytvořte novou automatizaci (přepněte do YAML režimu), která zachytí událost `APPDAEMON_READY`:
+V Home Assistantu pak vytvořte novou automatizaci (přepněte do YAML režimu), která zachytí událost `APPDAEMON_READY`:
 ```yaml
 alias: Run actions after AppDaemon starts
 description: Spustí PND po startu AppDaemonu s prodlevou 15 sekund pro zajištění závislostí

--- a/README.md
+++ b/README.md
@@ -191,16 +191,9 @@ mode: single
 ```
 
 ### Automatické spuštění po restartu AppDaemon
-Pokud chcete zajistit, aby se skript spustil automaticky po každém restartu AppDaemonu (např. po restartu celého Home Assistanta), můžete využít následující pomocný skript a automatizaci. Toto řešení pomáhá zejména v situacích, kdy se po startu systému skript sám nevyvolá (nápad a řešení od uživatele @wejto).
+Pokud chcete zajistit, aby se skript spustil automaticky po každém restartu AppDaemonu (např. po restartu celého Home Assistanta), můžete využít pomocný skript `init_helper.py` a automatizaci v Home Assistantu. Toto řešení pomáhá zejména v situacích, kdy se po startu systému skript sám nevyvolá (nápad a řešení od uživatele @wejto).
 
-1. Ve složce `apps/pnd/` (nebo tam, kde máte `pnd.py`) vytvořte nový soubor `init_helper.py` s tímto obsahem:
-```python
-import appdaemon.plugins.hass.hassapi as hass
-
-class InitHelper(hass.Hass):
-    def initialize(self):
-        self.fire_event("APPDAEMON_READY")
-```
+1. Ujistěte se, že ve složce `apps/pnd/` (nebo tam, kde máte `pnd.py`) existuje soubor `init_helper.py`.
 
 2. V souboru `apps.yaml` přidejte nad (nebo pod) definici `pnd` tento blok:
 ```yaml

--- a/apps/pnd/init_helper.py
+++ b/apps/pnd/init_helper.py
@@ -1,0 +1,5 @@
+import appdaemon.plugins.hass.hassapi as hass
+
+class InitHelper(hass.Hass):
+    def initialize(self):
+        self.fire_event("APPDAEMON_READY")

--- a/apps/pnd/pnd.py
+++ b/apps/pnd/pnd.py
@@ -1,7 +1,8 @@
-ver = "v1.0.0"
+ver = "v1.0.1"
 import appdaemon.plugins.hass.hassapi as hass
 import time
 import datetime
+import math
 import os
 import sys
 import shutil


### PR DESCRIPTION
This change implements a request to facilitate reliable automatic startup of the PND script after AppDaemon restarts. 

Key changes:
1.  **New Helper App**: Created `apps/pnd/init_helper.py` which fires a Home Assistant event `APPDAEMON_READY` when initialized. This allows users to create automations that trigger the main script once all dependencies are ready.
2.  **Bug Fix**: Added `import math` to `apps/pnd/pnd.py`, fixing a potential runtime error in the `_normalize_ha_state` function.
3.  **Documentation**: Updated `README.md` with a new section "Automatické spuštění po restartu AppDaemon" providing YAML examples for the `apps.yaml` configuration and the corresponding Home Assistant automation.
4.  **Version Bump**: Updated application version to `v1.0.1`.
5.  **Repository Cleanliness**: Added a `.gitignore` file to ensure `__pycache__` and other temporary Python files are not committed.

Fixes #92

---
*PR created automatically by Jules for task [7706960392351633103](https://jules.google.com/task/7706960392351633103) started by @ondrejvysek*